### PR TITLE
Feature/doc harmonization

### DIFF
--- a/docs/.vuepress/components/MapboxNavigationControlDemo.vue
+++ b/docs/.vuepress/components/MapboxNavigationControlDemo.vue
@@ -1,15 +1,8 @@
 <template>
-  <div>
-    <mapbox-map
-      style="margin-top: 1em; height: 400px;"
-      :access-token="MAPBOX_API_KEY"
-      map-style="mapbox://styles/mapbox/streets-v11">
-      <mapbox-navigation-control position="bottom-right" />
-    </mapbox-map>
-  </div>
+  <mapbox-map
+    style="height: 400px;"
+    :access-token="MAPBOX_API_KEY"
+    map-style="mapbox://styles/mapbox/streets-v11">
+    <mapbox-navigation-control position="bottom-right" />
+  </mapbox-map>
 </template>
-
-<style lang="scss">
-  // Import mapbox stylesheet to get + - and compass buttons styles
-  @import '~mapbox-gl/dist/mapbox-gl';
-</style>

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -5,15 +5,6 @@ const webpack = require('webpack');
 module.exports = {
   title: '🗺 Vue Mapbox GL',
   description: 'A small library of Vue components for mapbox-gl',
-  head: [
-    [
-      'link',
-      {
-        rel: 'stylesheet',
-        href: 'https://unpkg.com/mapbox-gl/dist/mapbox-gl.css',
-      },
-    ],
-  ],
   chainWebpack: (config) => {
     // Update babel-loader config to use the same configuration
     // as the project (especially the plugins).

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -1,0 +1,1 @@
+@import '~mapbox-gl/dist/mapbox-gl.css';

--- a/docs/components/MapboxImage.md
+++ b/docs/components/MapboxImage.md
@@ -61,7 +61,7 @@ Add an image to be used used in `icon-image`, `background-pattern`, `fill-patter
   </mapbox-map>
 </client-only>
 
-```vue
+```vue{7-9}
 <mapbox-map
   style="height: 400px"
   access-token="..."

--- a/docs/components/MapboxImages.md
+++ b/docs/components/MapboxImages.md
@@ -20,7 +20,7 @@ Add multiple images at once to be used used in `icon-image`, `background-pattern
   <mapbox-images-demo api-key="MAPBOX_API_KEY" />
 </client-only>
 
-<<< @/docs/.vuepress/components/MapboxImagesDemo.vue
+<<< @/docs/.vuepress/components/MapboxImagesDemo.vue{8-12,20-31,42,52,63}
 
 ## Props
 

--- a/docs/components/MapboxMap.md
+++ b/docs/components/MapboxMap.md
@@ -276,3 +276,15 @@ All events available on the Mapbox `Map` class are also available on the `Mapbox
 - ...
 
 See the [API Reference](https://docs.mapbox.com/mapbox-gl-js/api/#map.event:resize) on the subject for more detailed information about each event.
+
+## Slots
+
+### `default`
+
+The `default` slot must contain all other components as the `mapbox-gl` instance is provided by this component to be injected in all its children.
+
+See the documentation on [provide / inject](https://vuejs.org/v2/api/#provide-inject) for more informations.
+
+### `loader`
+
+This slot is displayed while the map is loading.

--- a/docs/components/MapboxMap.md
+++ b/docs/components/MapboxMap.md
@@ -79,7 +79,7 @@ Your Mapbox access token or `no-token` if you are not using a map style from Map
 - Type `[ String, Object ]`
 - Required `true`
 
-A map style definition, can be a JSON object following the [Mapbox Style specification] of an URL to such a JSON. This props is mapped to the `options.style` configuration on the map instantiation.
+A map style definition, can be a JSON object following the [Mapbox Style specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/) of an URL to such a JSON. This prop is mapped to the `options.style` configuration of the map creation.
 
 ### `container`
 
@@ -95,7 +95,6 @@ A map style definition, can be a JSON object following the [Mapbox Style specifi
 
 - Type `Number`
 - Default `22`
-
 
 ### `hash`
 

--- a/docs/components/MapboxMap.md
+++ b/docs/components/MapboxMap.md
@@ -40,7 +40,7 @@ It is recommended to have a look at their [API reference](https://docs.mapbox.co
 
 You will probably need to use the Mapbox instance to use some of its methods such as `flyTo`, `panTo`, etc. The `MapboxMap` component emits an `mb-ready` event right after the Mapbox instantiation, with the Mapbox instance of [`Map`](https://docs.mapbox.com/mapbox-gl-js/api/#map) as a parameter. See the example below:
 
-```vue{5,17}
+```vue{5,18}
 <template>
   <mapbox-map
     access-token="..."

--- a/docs/components/MapboxNavigationControl.md
+++ b/docs/components/MapboxNavigationControl.md
@@ -21,10 +21,10 @@ Display navigation controls on the map, including two zoom buttons + - and a com
 ### Basic usage
 
 <client-only>
-  <mapbox-navigation-control-demo api-key="MAPBOX_API_KEY" />
+  <mapbox-navigation-control-demo style="margin-top: 1em;" />
 </client-only>
 
-<<< @/docs/.vuepress/components/MapboxNavigationControlDemo.vue
+<<< @/docs/.vuepress/components/MapboxNavigationControlDemo.vue{6}
 
 ## Props
 


### PR DESCRIPTION
- Add missing slots documentation for the `MapboxMap` component (d05e4b3)
- Improve the handling of the mapbox-gl styles (68b7dde)
- Add line highlights to improve lisibility (72347d5)
- Fix a broken link to the Mapbox GL documentation (ffbc4fb)