### PR TITLE
Fix 'position' Prop on MapboxGeolocateControl

### DIFF
--- a/src/components/MapboxGeolocateControl.vue
+++ b/src/components/MapboxGeolocateControl.vue
@@ -41,8 +41,7 @@
     },
     position: {
       type: String,
-      default: 'top-right',
-      bind: false,
+      default: 'top-right'
     },
   };
 


### PR DESCRIPTION
Position-Prop won't be detected as property and so isn't passed to mapbox.