### PR TITLE
Fix doc regarding access token

### DIFF
--- a/packages/docs/components/MapboxMap/index.md
+++ b/packages/docs/components/MapboxMap/index.md
@@ -76,7 +76,7 @@ You will probably need to use the Mapbox instance to use some of its methods suc
 - Type `String`
 - Required `true`
 
-Your Mapbox access token or `no-token` if you are not using a map style from Mapbox.
+Your Mapbox access token.
 
 ### `mapStyle`
 

--- a/packages/docs/components/StoreLocator/index.md
+++ b/packages/docs/components/StoreLocator/index.md
@@ -112,7 +112,7 @@ The zoom level to use when zooming in on an item.
 - Type `String`
 - Default `no-token`
 
-Your Mapbox access token or no-token if you are not using a map style from Mapbox.
+Your Mapbox access token.
 
 ### `mapboxMap`
 


### PR DESCRIPTION
- In original PR: Fix #74: cf https://nodejs.org/api/deprecations.html#DEP0151. Removed from PR after @titouanmathis review
- Fix #67: remove hint that 'no-token' can be used for mapbox. Cf: https://github.com/mapbox/mapbox-gl-js/issues/10162