### PR TITLE
[Bugfix] Control not added to the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 
+- Fix a bug where controls could be accessed before being added to the map ([#82](https://github.com/studiometa/vue-mapbox-gl/pull/82), fix [#77](https://github.com/studiometa/vue-mapbox-gl/issues/77))
 - Fix Node warning about package.json fields ([3b5e4e7](https://github.com/studiometa/vue-mapbox-gl/commit/3b5e4e7), fix [#74](https://github.com/studiometa/vue-mapbox-gl/issues/74))
 - Fix CSS build file containing an invalid comment ([612c9e8](https://github.com/studiometa/vue-mapbox-gl/commit/612c9e8))
 

--- a/packages/vue-mapbox-gl/composables/useControl.js
+++ b/packages/vue-mapbox-gl/composables/useControl.js
@@ -36,11 +36,13 @@ export function useControl(ControlConstructor, { propsConfig, props, emit, event
   );
 
   onMounted(() => {
-    control.value = new ControlConstructor(props);
+    const ctrl = new ControlConstructor(props);
 
     if (unref(map)) {
-      unref(map).addControl(unref(control), props.position);
+      unref(map).addControl(ctrl, props.position);
     }
+
+    control.value = ctrl;
   });
 
   onUnmounted(() => {


### PR DESCRIPTION
This PR fixes a bug where controls could be accessed before being added to the map, resulting in mapbox-gl throwing an error/warning. 

Fix #77. 