### PR TITLE
[Bugfix] Cluster duplicate source ID

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'
-      - uses: antfu/export-size-action@v1
+      - uses: titouanmathis/export-size-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           build_script: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 
+- Fix cluster IDs not being incremented ([#83](https://github.com/studiometa/vue-mapbox-gl/pull/83), fix [#75](https://github.com/studiometa/vue-mapbox-gl/issues/75))
 - Fix a bug where controls could be accessed before being added to the map ([#82](https://github.com/studiometa/vue-mapbox-gl/pull/82), fix [#77](https://github.com/studiometa/vue-mapbox-gl/issues/77))
 - Fix Node warning about package.json fields ([3b5e4e7](https://github.com/studiometa/vue-mapbox-gl/commit/3b5e4e7), fix [#74](https://github.com/studiometa/vue-mapbox-gl/issues/74))
 - Fix CSS build file containing an invalid comment ([612c9e8](https://github.com/studiometa/vue-mapbox-gl/commit/612c9e8))

--- a/packages/vue-mapbox-gl/components/MapboxCluster.vue
+++ b/packages/vue-mapbox-gl/components/MapboxCluster.vue
@@ -118,6 +118,8 @@
       }),
     },
   };
+
+  let index = 0;
 </script>
 
 <script setup>
@@ -125,8 +127,6 @@
   import { useMap } from '../composables/index.js';
   import MapboxLayer from './MapboxLayer.vue';
   import MapboxSource from './MapboxSource.vue';
-
-  let index = 0;
 
   const props = defineProps(propsConfig);
   // eslint-disable-next-line vue/valid-define-emits

--- a/packages/vue-mapbox-gl/package.json
+++ b/packages/vue-mapbox-gl/package.json
@@ -27,6 +27,7 @@
     }
   ],
   "type": "module",
+  "main": "./index.js",
   "exports": {
     ".": {
       "import": "./index.js",


### PR DESCRIPTION
This PR fixes a bug where `MapboxCluster` ID were not correctly incremented.

Fix #75.