### PR TITLE
Check if event is defaultPrevented before move map

### DIFF
--- a/packages/vue-mapbox-gl/components/MapboxCluster.vue
+++ b/packages/vue-mapbox-gl/components/MapboxCluster.vue
@@ -195,6 +195,12 @@
 
     // Emit a cluster click event
     emit('mb-cluster-click', clusterId, event);
+
+    // Return before move map if event is defaultPrevented
+    if (event.defaultPrevented) {
+        return;
+    }
+
     unref(map)
       .getSource(unref(sourceId))
       .getClusterExpansionZoom(clusterId, (err, zoom) => {


### PR DESCRIPTION
The default behavior of clicking in a cluster mark is to zoom in and center the map at that point. If an user want to prevent that behavior can use the click event and call the preventDefault method