### PR TITLE
Add user heading for MapboxGeolocateControl

### DIFF
--- a/packages/docs/components/MapboxGeolocateControl/index.md
+++ b/packages/docs/components/MapboxGeolocateControl/index.md
@@ -74,6 +74,13 @@ If true the Geolocate Control becomes a toggle button and when active the map wi
 
 By default, if showUserLocation is true , a transparent circle will be drawn around the user location indicating the accuracy (95% confidence level) of the user's location. Set to false to disable. Always disabled when showUserLocation is false .
 
+### `showUserHeading`
+- Type `[ Boolean ]`
+- Required: `false`
+- Default `false`
+
+If `true` an arrow will be drawn next to the user location dot indicating the device's heading. This only has affect when `trackUserLocation` is `true`.
+
 ### `showUserLocation`
 - Type `[ Boolean ]`
 - Required: `false`

--- a/packages/vue-mapbox-gl/components/MapboxGeolocateControl.vue
+++ b/packages/vue-mapbox-gl/components/MapboxGeolocateControl.vue
@@ -34,11 +34,11 @@
       type: Boolean,
       default: true,
     },
-    showUserLocation: {
+    showUserHeading: {
       type: Boolean,
       default: true,
     },
-    showUserHeading: {
+    showUserLocation: {
       type: Boolean,
       default: true,
     },

--- a/packages/vue-mapbox-gl/components/MapboxGeolocateControl.vue
+++ b/packages/vue-mapbox-gl/components/MapboxGeolocateControl.vue
@@ -38,6 +38,10 @@
       type: Boolean,
       default: true,
     },
+    showUserHeading: {
+      type: Boolean,
+      default: true,
+    },
     position: {
       type: String,
       default: 'top-right',


### PR DESCRIPTION
Adds the `trackUserLocation` prop for the `MapboxGeolocateControl` — see [Mapbox docs](https://docs.mapbox.com/mapbox-gl-js/api/markers/#geolocatecontrol-parameters).