### PR TITLE
Update docs with center as ref

### DIFF
--- a/packages/demo/app.vue
+++ b/packages/demo/app.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { ref } from 'vue';
+  import { ref, computed } from 'vue';
   import {
     MapboxGeocoder,
     MapboxGeolocateControl,
@@ -20,6 +20,7 @@
   const lng = ref(0);
   const lat = ref(0);
   const zoom = ref(1);
+  const mapCenter = computed(() => [lng.value, lat.value]);
   const createdHandler = () => console.log('Map created!');
 
   const eventHandler = console.log.bind(null, '[Event]');
@@ -81,7 +82,7 @@
         style="height: 400px"
         :access-token="accessToken"
         map-style="mapbox://styles/mapbox/streets-v11"
-        :center="[lng, lat]"
+        :center="mapCenter"
         :zoom="zoom"
       >
         <MapboxImages :sources="iconSources">
@@ -139,12 +140,12 @@
       <fieldset class="controls__group">
         <legend>Longitude</legend>
         <input type="text" readonly="readonly" :value="lng" />
-        <input type="range" step="1" v-model="lng" />
+        <input type="range" step="1"  min="-100" max="100" v-model="lng" />
       </fieldset>
       <fieldset class="controls__group">
         <legend>Latitude</legend>
         <input type="text" readonly="readonly" :value="lat" />
-        <input type="range" step="1" v-model="lat" />
+        <input type="range" step="1" min="-90" max="90" v-model="lat" />
       </fieldset>
       <fieldset class="controls__group">
         <legend>Zoom</legend>

--- a/packages/docs/.vitepress/components/MapboxClusterWithCustomImageDemo.vue
+++ b/packages/docs/.vitepress/components/MapboxClusterWithCustomImageDemo.vue
@@ -2,7 +2,7 @@
   import { ref } from "vue";
   import { MapboxMap, MapboxImage, MapboxCluster } from '@studiometa/vue-mapbox-gl';
 
-  const center = ref([0, 0]);
+  const mapCenter = ref([0, 0]);
 </script>
 
 <template>
@@ -10,7 +10,7 @@
     style="height: 400px"
     :access-token="MAPBOX_API_KEY"
     map-style="mapbox://styles/mapbox/streets-v11"
-    :center="center"
+    :center="mapCenter"
     :zoom="1">
     <MapboxImage
       id="cat"

--- a/packages/docs/.vitepress/components/MapboxClusterWithCustomImageDemo.vue
+++ b/packages/docs/.vitepress/components/MapboxClusterWithCustomImageDemo.vue
@@ -1,5 +1,8 @@
 <script setup>
+  import { ref } from "vue";
   import { MapboxMap, MapboxImage, MapboxCluster } from '@studiometa/vue-mapbox-gl';
+
+  const center = ref([0, 0]);
 </script>
 
 <template>
@@ -7,7 +10,7 @@
     style="height: 400px"
     :access-token="MAPBOX_API_KEY"
     map-style="mapbox://styles/mapbox/streets-v11"
-    :center="[0, 0]"
+    :center="center"
     :zoom="1">
     <MapboxImage
       id="cat"

--- a/packages/docs/.vitepress/components/MapboxImagesDemo.vue
+++ b/packages/docs/.vitepress/components/MapboxImagesDemo.vue
@@ -1,5 +1,8 @@
 <script setup>
+  import { ref } from "vue";
   import { MapboxMap, MapboxImages, MapboxLayer } from '@studiometa/vue-mapbox-gl';
+
+  const mapCenter = ref([0, 0]);
 
   const images = [
     {
@@ -54,7 +57,7 @@
     style="height: 400px"
     :access-token="MAPBOX_API_KEY"
     map-style="mapbox://styles/mapbox/streets-v11"
-    :center="[0, 0]"
+    :center="mapCenter"
     :zoom="1">
     <MapboxImages :sources="images">
       <MapboxLayer id="pois" :options="layerOptions" />

--- a/packages/docs/.vitepress/components/MapboxMarkerCustomHtmlDemo.vue
+++ b/packages/docs/.vitepress/components/MapboxMarkerCustomHtmlDemo.vue
@@ -2,7 +2,7 @@
   import { ref } from "vue";
   import { MapboxMap, MapboxMarker } from '@studiometa/vue-mapbox-gl';
 
-  const center = ref([0, 0]);
+  const mapCenter = ref([0, 0]);
 </script>
 
 <template>
@@ -10,7 +10,7 @@
     style="height: 400px"
     :access-token="MAPBOX_API_KEY"
     map-style="mapbox://styles/mapbox/streets-v11"
-    :center="center"
+    :center="mapCenter"
     :zoom="1">
     <MapboxMarker :lng-lat="[0, 0]">
       <p class="custom-marker">Hello world!</p>

--- a/packages/docs/.vitepress/components/MapboxMarkerCustomHtmlDemo.vue
+++ b/packages/docs/.vitepress/components/MapboxMarkerCustomHtmlDemo.vue
@@ -1,5 +1,8 @@
 <script setup>
+  import { ref } from "vue";
   import { MapboxMap, MapboxMarker } from '@studiometa/vue-mapbox-gl';
+
+  const center = ref([0, 0]);
 </script>
 
 <template>
@@ -7,7 +10,7 @@
     style="height: 400px"
     :access-token="MAPBOX_API_KEY"
     map-style="mapbox://styles/mapbox/streets-v11"
-    :center="[0, 0]"
+    :center="center"
     :zoom="1">
     <MapboxMarker :lng-lat="[0, 0]">
       <p class="custom-marker">Hello world!</p>

--- a/packages/docs/.vitepress/components/MapboxMarkerPopupDemo.vue
+++ b/packages/docs/.vitepress/components/MapboxMarkerPopupDemo.vue
@@ -1,5 +1,8 @@
 <script setup>
+  import { ref } from "vue";
   import { MapboxMap, MapboxMarker } from '@studiometa/vue-mapbox-gl';
+
+  const mapCenter = ref([0, 0]);
 </script>
 
 <template>
@@ -7,7 +10,7 @@
     style="height: 400px"
     :access-token="MAPBOX_API_KEY"
     map-style="mapbox://styles/mapbox/streets-v11"
-    :center="[0, 0]"
+    :center="mapCenter"
     :zoom="1">
     <MapboxMarker :lng-lat="[0, 0]" popup>
       <template v-slot:popup>

--- a/packages/docs/components/MapboxImage/index.md
+++ b/packages/docs/components/MapboxImage/index.md
@@ -1,5 +1,8 @@
 <script setup>
+  import { ref } from "vue";
   import { MapboxMap, MapboxImage, MapboxLayer } from '@studiometa/vue-mapbox-gl';
+
+  const mapCenter = ref([0, 0]);
 </script>
 
 # MapboxImage
@@ -24,7 +27,7 @@ Add an image to be used used in `icon-image`, `background-pattern`, `fill-patter
     style="margin-top: 1em; height: 400px;"
     :access-token="MAPBOX_API_KEY"
     map-style="mapbox://styles/mapbox/streets-v11"
-    :center="[0, 0]"
+    :center="mapCenter"
     :zoom="1">
   <MapboxImage
     src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/60/Cat_silhouette.svg/400px-Cat_silhouette.svg.png"
@@ -59,7 +62,10 @@ Add an image to be used used in `icon-image`, `background-pattern`, `fill-patter
 
 ```vue {12-14}
 <script setup>
+  import { ref } from "vue";
   import { MapboxMap, MapboxImage } from '@studiometa/vue-mapbox-gl';
+
+  const mapCenter = ref([0, 0]);
 </script>
 
 <template>
@@ -67,7 +73,7 @@ Add an image to be used used in `icon-image`, `background-pattern`, `fill-patter
     style="height: 400px"
     access-token="..."
     map-style="mapbox://styles/mapbox/streets-v11"
-    :center="[0, 0]"
+    :center="mapCenter"
     :zoom="1">
     <MapboxImage
       src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/60/Cat_silhouette.svg/400px-Cat_silhouette.svg.png"

--- a/packages/docs/components/MapboxMap/index.md
+++ b/packages/docs/components/MapboxMap/index.md
@@ -2,7 +2,7 @@
   import { ref } from "vue";
   import { MapboxMap } from '@studiometa/vue-mapbox-gl';
 
-  const center = ref([0, 0]);
+  const mapCenter = ref([0, 0]);
 </script>
 
 # MapboxMap
@@ -24,7 +24,7 @@ It is recommended to have a look at their [API reference](https://docs.mapbox.co
     style="margin-top: 1em; height: 400px;"
     :access-token="MAPBOX_API_KEY"
     map-style="mapbox://styles/mapbox/streets-v11"
-    :center="center"
+    :center="mapCenter"
     :zoom="1" />
 </ClientOnly>
 
@@ -33,7 +33,7 @@ It is recommended to have a look at their [API reference](https://docs.mapbox.co
   import { ref } from "vue";
   import { MapboxMap } from '@studiometa/vue-mapbox-gl';
 
-  const center = ref([0, 0]);
+  const mapCenter = ref([0, 0]);
 </script>
 
 <template>
@@ -41,7 +41,7 @@ It is recommended to have a look at their [API reference](https://docs.mapbox.co
     style="height: 400px"
     access-token="..."
     map-style="mapbox://styles/mapbox/streets-v11"
-    :center="center"
+    :center="mapCenter"
     :zoom="1" />
 </template>
 ```

--- a/packages/docs/components/MapboxMap/index.md
+++ b/packages/docs/components/MapboxMap/index.md
@@ -1,5 +1,8 @@
 <script setup>
+  import { ref } from "vue";
   import { MapboxMap } from '@studiometa/vue-mapbox-gl';
+
+  const center = ref([0, 0]);
 </script>
 
 # MapboxMap
@@ -21,13 +24,16 @@ It is recommended to have a look at their [API reference](https://docs.mapbox.co
     style="margin-top: 1em; height: 400px;"
     :access-token="MAPBOX_API_KEY"
     map-style="mapbox://styles/mapbox/streets-v11"
-    :center="[0, 0]"
+    :center="center"
     :zoom="1" />
 </ClientOnly>
 
 ```vue
 <script setup>
+  import { ref } from "vue";
   import { MapboxMap } from '@studiometa/vue-mapbox-gl';
+
+  const center = ref([0, 0]);
 </script>
 
 <template>
@@ -35,7 +41,7 @@ It is recommended to have a look at their [API reference](https://docs.mapbox.co
     style="height: 400px"
     access-token="..."
     map-style="mapbox://styles/mapbox/streets-v11"
-    :center="[0, 0]"
+    :center="center"
     :zoom="1" />
 </template>
 ```


### PR DESCRIPTION
As discussed here https://github.com/studiometa/vue-mapbox-gl/issues/90#issuecomment-1420973410 I changed all center values to refs.

In the demo I used a computed value, but I don't know if this is intended. I added min, max Range to the inputs because it threw an error for lat and it allows to scroll up/down and left/right.

On a side note, there is an error in `MapboxGeocoder` and `StoreLocator` because of the line `unref(control).addTo(unref(root));` which results in the error `Cannot read properties of undefined (reading 'addTo')`. I don't know how to solve that though.