### PR TITLE
[Feature] Add support for the `clusterProperties` and `clusterMinPoints` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+
+- Add support for the `clusterProperties` option ([4a55844](https://github.com/studiometa/vue-mapbox-gl/commit/4a55844), [#119](https://github.com/studiometa/vue-mapbox-gl/pull/119), fix [#117](https://github.com/studiometa/vue-mapbox-gl/issues/117))
+- Add support for the `clusterMinPoints` option ([4e403c7](https://github.com/studiometa/vue-mapbox-gl/commit/4e403c7), [#119](https://github.com/studiometa/vue-mapbox-gl/pull/119))
+
 ### Fixed
 
 - Fix a bug where the geolocate control could be accessed before being added to the map ([3f8eaef](https://github.com/studiometa/vue-mapbox-gl/commit/3f8eaef), [#106](https://github.com/studiometa/vue-mapbox-gl/pull/106), fix [#77](https://github.com/studiometa/vue-mapbox-gl/issues/77))

--- a/packages/docs/components/MapboxCluster/index.md
+++ b/packages/docs/components/MapboxCluster/index.md
@@ -86,7 +86,21 @@ The max zoom to cluster points on.
 - Type `Number`
 - Default `50`
 
-Radius of each cluster when clustering point
+Radius of each cluster when clustering point.
+
+### `clusterMinPoints`
+
+- Type `Number`
+- Default `2`
+
+Minimum number of points necessary to form a cluster.
+
+### `clusterProperties`
+
+- Type `Object`
+- Default `{}}`
+
+An object defining custom properties on the generated clusters.
 
 ### `clustersLayout`
 

--- a/packages/vue-mapbox-gl/components/MapboxCluster.vue
+++ b/packages/vue-mapbox-gl/components/MapboxCluster.vue
@@ -50,13 +50,13 @@
      */
     clusterMinPoints: {
       type: Number,
-      default: 2
+      default: 2,
     },
     /**
      * An object defining custom properties on the generated clusters.
      * @see  https://docs.mapbox.com/style-spec/reference/sources/#geojson-clusterProperties
      * @see  https://docs.mapbox.com/mapbox-gl-js/example/cluster-html/
-     * @type {Object}
+     * @type {object}
      */
     clusterProperties: {
       type: Object,

--- a/packages/vue-mapbox-gl/components/MapboxCluster.vue
+++ b/packages/vue-mapbox-gl/components/MapboxCluster.vue
@@ -53,6 +53,16 @@
       default: 2
     },
     /**
+     * An object defining custom properties on the generated clusters.
+     * @see  https://docs.mapbox.com/style-spec/reference/sources/#geojson-clusterProperties
+     * @see  https://docs.mapbox.com/mapbox-gl-js/example/cluster-html/
+     * @type {Object}
+     */
+    clusterProperties: {
+      type: Object,
+      default: () => ({}),
+    },
+    /**
      * The layout configuration for the clusters circles
      * @see  https://docs.mapbox.com/mapbox-gl-js/example/cluster/
      * @type {object}
@@ -148,7 +158,7 @@
 
   const sourceId = computed(() => getId('source'));
   const source = computed(() => {
-    const { data, clusterMaxZoom, clusterRadius, clusterMinPoints } = props;
+    const { data, clusterMaxZoom, clusterRadius, clusterMinPoints, clusterProperties } = props;
     return {
       type: 'geojson',
       cluster: true,
@@ -156,6 +166,7 @@
       clusterMaxZoom,
       clusterRadius,
       clusterMinPoints,
+      clusterProperties,
     };
   });
 

--- a/packages/vue-mapbox-gl/components/MapboxCluster.vue
+++ b/packages/vue-mapbox-gl/components/MapboxCluster.vue
@@ -45,6 +45,14 @@
       default: 50,
     },
     /**
+     * Minimum number of points necessary to form a cluster.
+     * @type {number}
+     */
+    clusterMinPoints: {
+      type: Number,
+      default: 2
+    },
+    /**
      * The layout configuration for the clusters circles
      * @see  https://docs.mapbox.com/mapbox-gl-js/example/cluster/
      * @type {object}
@@ -140,13 +148,14 @@
 
   const sourceId = computed(() => getId('source'));
   const source = computed(() => {
-    const { data, clusterMaxZoom, clusterRadius } = props;
+    const { data, clusterMaxZoom, clusterRadius, clusterMinPoints } = props;
     return {
       type: 'geojson',
       cluster: true,
       data,
       clusterMaxZoom,
       clusterRadius,
+      clusterMinPoints,
     };
   });
 


### PR DESCRIPTION
## Changelog 

### Added

- Add support for the `clusterProperties` option ([4a55844](https://github.com/studiometa/vue-mapbox-gl/commit/4a55844), [#119](https://github.com/studiometa/vue-mapbox-gl/pull/119), fix [#117](https://github.com/studiometa/vue-mapbox-gl/issues/117))
- Add support for the `clusterMinPoints` option ([4e403c7](https://github.com/studiometa/vue-mapbox-gl/commit/4e403c7), [#119](https://github.com/studiometa/vue-mapbox-gl/pull/119))
