### PR TITLE
[Feature] Add options to `MapboxMap` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - Add support for the `clusterProperties` option ([4a55844](https://github.com/studiometa/vue-mapbox-gl/commit/4a55844), [#119](https://github.com/studiometa/vue-mapbox-gl/pull/119), fix [#117](https://github.com/studiometa/vue-mapbox-gl/issues/117))
 - Add support for the `clusterMinPoints` option ([4e403c7](https://github.com/studiometa/vue-mapbox-gl/commit/4e403c7), [#119](https://github.com/studiometa/vue-mapbox-gl/pull/119))
+- Add props to the `MapboxMap` component ([79d2929](https://github.com/studiometa/vue-mapbox-gl/commit/79d2929), [#121](https://github.com/studiometa/vue-mapbox-gl/pull/121), fix [#108](https://github.com/studiometa/vue-mapbox-gl/issues/108))
 
 ### Fixed
 

--- a/packages/docs/components/MapboxMap/index.md
+++ b/packages/docs/components/MapboxMap/index.md
@@ -30,7 +30,7 @@ It is recommended to have a look at their [API reference](https://docs.mapbox.co
 
 ```vue
 <script setup>
-  import { ref } from "vue";
+  import { ref } from 'vue';
   import { MapboxMap } from '@studiometa/vue-mapbox-gl';
 
   const mapCenter = ref([0, 0]);
@@ -285,6 +285,70 @@ A map style definition, can be a JSON object following the [Mapbox Style specifi
 
 - Type `Boolean`
 - Default `true`
+
+### `cooperativeGestures`
+
+- Type: `Boolean`
+- Default: `false`
+
+### `language`
+
+- Type: `["auto", String, Array]`
+- Default: `null`
+
+### `locale`
+
+- Type: `Object`
+- Default: `null`
+
+### `localFontFamily`
+
+- Type: `String`
+- Default: `false`
+
+### `minTileCacheSize`
+
+- Type: `Number`
+- Default: `null`
+
+### `optimizeForTerrain`
+
+- Type: `Boolean`
+- Default: `true`
+
+### `performanceMetricsCollection`
+
+- Type: `Boolean`
+- Default: `true`
+
+### `projection`
+
+- Type: `ProjectionSpecification`
+- Default: `'mercator'`
+
+### `style`
+
+- Type: `[Object, String]`
+
+### `testMode`
+
+- Type: `Boolean`
+- Default: `false`
+
+### `touchPitch`
+
+- Type: `[Boolean, Object]`
+- Default: `true`
+
+### `useWebGL2`
+
+- Type: `Boolean`
+- Default: `false`
+
+### `worldview`
+
+- Type: `String`
+- Default: `null`
 
 ## Events
 

--- a/packages/vue-mapbox-gl/components/MapboxMap.vue
+++ b/packages/vue-mapbox-gl/components/MapboxMap.vue
@@ -192,11 +192,11 @@
       type: Boolean,
     },
     language: {
-      type: ["auto", String, Array],
+      type: [String, Array],
       default: null,
     },
     locale: {
-      type: 'Object',
+      type: Object,
       default: null,
     },
     localFontFamily: {
@@ -216,7 +216,7 @@
       default: true,
     },
     projection: {
-      type: 'ProjectionSpecification',
+      type: [String, Object],
       default: 'mercator',
     },
     style: {

--- a/packages/vue-mapbox-gl/components/MapboxMap.vue
+++ b/packages/vue-mapbox-gl/components/MapboxMap.vue
@@ -200,7 +200,7 @@
       default: null,
     },
     localFontFamily: {
-      type: String,
+      type: [Boolean, String],
       default: false,
     },
     minTileCacheSize: {

--- a/packages/vue-mapbox-gl/components/MapboxMap.vue
+++ b/packages/vue-mapbox-gl/components/MapboxMap.vue
@@ -219,9 +219,6 @@
       type: [String, Object],
       default: 'mercator',
     },
-    style: {
-      type: [Object, String],
-    },
     testMode: {
       type: Boolean,
       default: false,

--- a/packages/vue-mapbox-gl/components/MapboxMap.vue
+++ b/packages/vue-mapbox-gl/components/MapboxMap.vue
@@ -188,6 +188,56 @@
       type: Boolean,
       default: true,
     },
+    cooperativeGestures: {
+      type: Boolean,
+    },
+    language: {
+      type: ["auto", String, Array],
+      default: null,
+    },
+    locale: {
+      type: 'Object',
+      default: null,
+    },
+    localFontFamily: {
+      type: String,
+      default: false,
+    },
+    minTileCacheSize: {
+      type: Number,
+      default: null,
+    },
+    optimizeForTerrain: {
+      type: Boolean,
+      default: true,
+    },
+    performanceMetricsCollection: {
+      type: Boolean,
+      default: true,
+    },
+    projection: {
+      type: 'ProjectionSpecification',
+      default: 'mercator',
+    },
+    style: {
+      type: [Object, String],
+    },
+    testMode: {
+      type: Boolean,
+      default: false,
+    },
+    touchPitch: {
+      type: [Boolean, Object],
+      default: true,
+    },
+    useWebGL2: {
+      type: Boolean,
+      default: false,
+    },
+    worldview: {
+      type: String,
+      default: null,
+    },
   };
 
   /**


### PR DESCRIPTION
## Changelog

### Added
- Add props to the `MapboxMap` component ([79d2929](https://github.com/studiometa/vue-mapbox-gl/commit/79d2929), [#121](https://github.com/studiometa/vue-mapbox-gl/pull/121), fix [#108](https://github.com/studiometa/vue-mapbox-gl/issues/108))