### PR TITLE
Feature/add callback to filter items

### DIFF
--- a/packages/docs/components/StoreLocator/index.md
+++ b/packages/docs/components/StoreLocator/index.md
@@ -212,6 +212,13 @@ interface StoreLocatorClassesProp {
 }
 ```
 
+### `filterItemsCallback`
+
+- Type `Function|Boolean`
+- Default `false`
+
+Props to add a custom filtering on the `items` props. That is triggered on `onMapCreated` `onMapMoveend` event.
+
 ## Events
 
 ### `map-created`

--- a/packages/vue-mapbox-gl/components/StoreLocator/StoreLocator.vue
+++ b/packages/vue-mapbox-gl/components/StoreLocator/StoreLocator.vue
@@ -102,6 +102,15 @@
         };
       },
     },
+
+    /**
+     * Filter items callback function
+     * @type {Function}
+     */
+    filterItemsCallback: {
+      type: [Function, Boolean],
+      default: false,
+    }
   });
   const emit = defineEmits();
 
@@ -163,6 +172,10 @@
 
         return 0;
       });
+
+    if (props.filterItemsCallback && typeof props.filterItemsCallback === 'function') {
+      filteredItems.value = await props.filterItemsCallback(filteredItems.value, map.value);
+    }
 
     await nextTick();
     listIsLoading.value = false;

--- a/packages/vue-mapbox-gl/components/StoreLocator/StoreLocator.vue
+++ b/packages/vue-mapbox-gl/components/StoreLocator/StoreLocator.vue
@@ -110,7 +110,7 @@
     filterItemsCallback: {
       type: [Function, Boolean],
       default: false,
-    }
+    },
   });
   const emit = defineEmits();
 


### PR DESCRIPTION
## Add
- Add filterItemsCallback props to allow custom filtering on the items displayed on the StoreLocator

