### PR TITLE
[Feature ] No zoom on feature click prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 
-- Add `disableFeatureClickZoom` prop to disable the zoom on feature click ([#136](https://github.com/studiometa/vue-mapbox-gl/pull/136))
+- **StoreLocator:** add `disableFeatureClickZoom` prop to disable the zoom on feature click ([#136](https://github.com/studiometa/vue-mapbox-gl/pull/136))
 
 ## [v2.4.0](https://github.com/studiometa/vue-mapbox-gl/compare/2.3.4...2.4.0) (2024-02-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+
+- Add `disableFeatureClickZoom` prop to disable the zoom on feature click ([#136](https://github.com/studiometa/vue-mapbox-gl/pull/136))
+
 ## [v2.4.0](https://github.com/studiometa/vue-mapbox-gl/compare/2.3.4...2.4.0) (2024-02-23)
 
 ### Added

--- a/packages/docs/components/StoreLocator/index.md
+++ b/packages/docs/components/StoreLocator/index.md
@@ -219,6 +219,13 @@ interface StoreLocatorClassesProp {
 
 Props to add a custom filtering on the `items` props. That is triggered on `onMapCreated` `onMapMoveend` event.
 
+### `disableFeatureClickZoom`
+
+- Type `Boolean`
+- Default `false`
+
+Disable the zoom on a feature click.
+
 ## Events
 
 ### `map-created`

--- a/packages/vue-mapbox-gl/components/StoreLocator/StoreLocator.vue
+++ b/packages/vue-mapbox-gl/components/StoreLocator/StoreLocator.vue
@@ -111,6 +111,11 @@
       type: [Function, Boolean],
       default: false,
     },
+
+    /**
+     * Disable the zoom when clicking on a Feature.
+     */
+    disableFeatureClickZoom: Boolean,
   });
   const emit = defineEmits();
 
@@ -265,6 +270,10 @@
   function onClusterFeatureClick(feature, event) {
     const item = props.items.find(({ id }) => id === feature.properties.id);
     emit('cluster-feature-click', feature, event);
+
+    if (props.disableFeatureClickZoom) {
+      return;
+    }
 
     if (item) {
       emit('select-item', item);

--- a/packages/vue-mapbox-gl/components/StoreLocator/StoreLocator.vue
+++ b/packages/vue-mapbox-gl/components/StoreLocator/StoreLocator.vue
@@ -271,13 +271,14 @@
     const item = props.items.find(({ id }) => id === feature.properties.id);
     emit('cluster-feature-click', feature, event);
 
-    if (props.disableFeatureClickZoom) {
-      return;
-    }
-
     if (item) {
       emit('select-item', item);
       selectedItem.value = item;
+
+      if (props.disableFeatureClickZoom) {
+        return;
+      }
+
       unref(map).flyTo({ center: feature.geometry.coordinates, zoom: props.itemZoomLevel });
     }
   }


### PR DESCRIPTION
This PR aims to add a new prop: `disableFeatureClickZoom`

When this prop is used the `<StoreLocator>` component won't automatically zoom to a feature location on a click.