### PR TITLE
[Release] 2.7.0-alpha.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish-and-release:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
@@ -35,6 +35,9 @@ jobs:
           restore-keys: ${{ runner.os }}-node-
 
       - run: npm install --no-audit --no-fund
+
+      - name: Install Playwright Dependencies
+        run: npx playwright install chromium --with-deps
 
       - run: npm run build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [v2.7.0-alpha.2](https://github.com/studiometa/vue-mapbox-gl/compare/2.7.0-alpha.1...2.7.0-alpha.2) (2025-01-24)
+
+### Fixed
+
+- Fix NPM publish ([8a9df54](https://github.com/studiometa/vue-mapbox-gl/commit/8a9df54))
+
+### Dependencies
+
+- Update dependency vue-tsc to v2.2.0 ([#229](https://github.com/studiometa/vue-mapbox-gl/pull/229), [40dce9e](https://github.com/studiometa/vue-mapbox-gl/commit/40dce9e))
+
 ## [v2.7.0-alpha.1](https://github.com/studiometa/vue-mapbox-gl/compare/2.7.0-alpha.0...2.7.0-alpha.1) (2025-01-24)
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/vue-mapbox-gl-workspace",
-  "version": "2.7.0-alpha.1",
+  "version": "2.7.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/vue-mapbox-gl-workspace",
-      "version": "2.7.0-alpha.1",
+      "version": "2.7.0-alpha.2",
       "workspaces": [
         "packages/*"
       ],
@@ -18451,7 +18451,7 @@
     },
     "packages/demo": {
       "name": "@studiometa/vue-mapbox-gl-demo",
-      "version": "2.7.0-alpha.1",
+      "version": "2.7.0-alpha.2",
       "dependencies": {
         "@mapbox/mapbox-gl-geocoder": "^5.0.3",
         "@studiometa/vue-mapbox-gl": "*",
@@ -18462,7 +18462,7 @@
     },
     "packages/docs": {
       "name": "@studiometa/vue-mapbox-gl-docs",
-      "version": "2.7.0-alpha.1",
+      "version": "2.7.0-alpha.2",
       "devDependencies": {
         "sass": "1.83.4",
         "tailwindcss": "3.4.17",
@@ -18471,7 +18471,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/vue-mapbox-gl-tests",
-      "version": "2.7.0-alpha.1",
+      "version": "2.7.0-alpha.2",
       "dependencies": {
         "@mapbox/mapbox-gl-geocoder": "^5.0.3",
         "@studiometa/vue-mapbox-gl": "*",
@@ -18487,7 +18487,7 @@
     },
     "packages/vue-mapbox-gl": {
       "name": "@studiometa/vue-mapbox-gl",
-      "version": "2.7.0-alpha.1",
+      "version": "2.7.0-alpha.2",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@mapbox/mapbox-gl-geocoder": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@studiometa/vue-mapbox-gl-workspace",
   "private": true,
-  "version": "2.7.0-alpha.1",
+  "version": "2.7.0-alpha.2",
   "type": "module",
   "workspaces": [
     "packages/*"

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/vue-mapbox-gl-demo",
-  "version": "2.7.0-alpha.1",
+  "version": "2.7.0-alpha.2",
   "scripts": {
     "dev": "nuxt dev",
     "build": "nuxt build"

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -2,7 +2,7 @@
   "name": "@studiometa/vue-mapbox-gl-docs",
   "private": true,
   "type": "module",
-  "version": "2.7.0-alpha.1",
+  "version": "2.7.0-alpha.2",
   "scripts": {
     "dev": "vitepress",
     "build": "vitepress build"

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/vue-mapbox-gl-tests",
-  "version": "2.7.0-alpha.1",
+  "version": "2.7.0-alpha.2",
   "type": "module",
   "scripts": {
     "test": "vitest"

--- a/packages/vue-mapbox-gl/package.json
+++ b/packages/vue-mapbox-gl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/vue-mapbox-gl",
-  "version": "2.7.0-alpha.1",
+  "version": "2.7.0-alpha.2",
   "description": "A small components library to use Mapbox GL in Vue 3.",
   "homepage": "https://github.com/studiometa/vue-mapbox-gl#readme",
   "bugs": {


### PR DESCRIPTION
### Fixed

- Fix NPM publish ([8a9df54](https://github.com/studiometa/vue-mapbox-gl/commit/8a9df54))

### Dependencies

- Update dependency vue-tsc to v2.2.0 ([#229](https://github.com/studiometa/vue-mapbox-gl/pull/229), [40dce9e](https://github.com/studiometa/vue-mapbox-gl/commit/40dce9e))
