### PR TITLE
[Bugfix] JS error on control removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Mapbox trying to remove controls already removed ([#249](https://github.com/studiometa/vue-mapbox-gl/issues/249), [#259](https://github.com/studiometa/vue-mapbox-gl/pull/259), [0bfaea6](https://github.com/studiometa/vue-mapbox-gl/commit/0bfaea6))
+
 ## [v2.7.1](https://github.com/studiometa/vue-mapbox-gl/compare/2.7.0...2.7.1) (2025-02-04)
 
 ### Changed

--- a/packages/demo/pages/issue-249.vue
+++ b/packages/demo/pages/issue-249.vue
@@ -1,0 +1,25 @@
+<script setup>
+  import { ref } from 'vue';
+  import { MapboxMap, MapboxGeocoder } from '@studiometa/vue-mapbox-gl';
+  import 'mapbox-gl/dist/mapbox-gl.css';
+  import '@mapbox/mapbox-gl-geocoder/lib/mapbox-gl-geocoder.css';
+
+  const config = useRuntimeConfig();
+  const showMap = ref(true);
+</script>
+
+<template>
+  <div>
+    <label>
+      <input v-model="showMap" type="checkbox" />
+      toggle map
+    </label>
+    <MapboxMap
+      v-if="showMap"
+      style="height: 60vh"
+      :access-token="config.public.accessToken"
+      map-style="mapbox://styles/mapbox/streets-v11">
+      <MapboxGeocoder />
+    </MapboxMap>
+  </div>
+</template>

--- a/packages/vue-mapbox-gl/composables/useControl.ts
+++ b/packages/vue-mapbox-gl/composables/useControl.ts
@@ -62,7 +62,7 @@ export function useControl(ControlConstructor, { propsConfig, props, emit, event
   });
 
   onUnmounted(() => {
-    if (unref(control) && unref(map)) {
+    if (unref(control) && unref(map) && unref(map).hasControl(unref(control))) {
       unref(map).removeControl(unref(control));
     }
   });


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

#249 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When unmounting the `MapboxMap` component, we call the `map.remove()` methods, which loops over all added controls and removes them. But, controls are also removed inside the `useControl` composable on unmount. This works fine with some controls but fails with the `MapboxGeocoder` component: it is first removed when calling `map.remove()` and then we try to remove it a second time, which fails because the container DOM element has already been removed (see https://github.com/mapbox/mapbox-gl-geocoder/blob/66c236f1f52d69bc2e2b5b8fb3ecc5255fc46acf/lib/index.js#L396-L408). 

The fix is simple : we check if the map still has the control we want to remove before removing it, preventing calling the control's `onRemove` method twice. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog.
